### PR TITLE
[08] Octavo pequeño paso del refactor

### DIFF
--- a/Java/src/main/java/com/gildedrose/GildedRose.java
+++ b/Java/src/main/java/com/gildedrose/GildedRose.java
@@ -16,6 +16,9 @@ class GildedRose {
     }
 
     private ItemCategory categorizeItem(Item item) {
+        if (item.name.equals("Sulfuras, Hand of Ragnaros")) {
+            return new SulfurasCategory();
+        }
         return new RegularItemCategory();
     }
 

--- a/Java/src/main/java/com/gildedrose/ItemCategory.java
+++ b/Java/src/main/java/com/gildedrose/ItemCategory.java
@@ -16,7 +16,9 @@ public interface ItemCategory {
 
     void updateQuality(Item item);
 
-    void updateSellIn(Item item);
+    default void updateSellIn(Item item) {
+        item.sellIn--;
+    }
 
     void updateExpired(Item item);
 }

--- a/Java/src/main/java/com/gildedrose/RegularItemCategory.java
+++ b/Java/src/main/java/com/gildedrose/RegularItemCategory.java
@@ -16,18 +16,9 @@ public class RegularItemCategory implements ItemCategory {
             if (item.sellIn < 6) {
                 incrementQuality(item);
             }
-        } else if (item.name.equals("Sulfuras, Hand of Ragnaros")) {
         } else {
             decrementQuality(item);
         }
-    }
-
-    @Override
-    public void updateSellIn(Item item) {
-        if (item.name.equals("Sulfuras, Hand of Ragnaros")) {
-            return;
-        }
-        item.sellIn--;
     }
 
     @Override
@@ -36,7 +27,6 @@ public class RegularItemCategory implements ItemCategory {
             incrementQuality(item);
         } else if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
             item.quality = 0;
-        } else if (item.name.equals("Sulfuras, Hand of Ragnaros")) {
         } else {
             decrementQuality(item);
         }

--- a/Java/src/main/java/com/gildedrose/SulfurasCategory.java
+++ b/Java/src/main/java/com/gildedrose/SulfurasCategory.java
@@ -1,0 +1,14 @@
+package com.gildedrose;
+
+public class SulfurasCategory implements ItemCategory {
+
+    @Override
+    public void updateQuality(Item item) { }
+
+    @Override
+    public void updateSellIn(Item item) { }
+
+    @Override
+    public void updateExpired(Item item) { }
+
+}

--- a/Java/src/test/java/com/gildedrose/GildedRoseTest.java
+++ b/Java/src/test/java/com/gildedrose/GildedRoseTest.java
@@ -21,7 +21,8 @@ public class GildedRoseTest {
                 new Item("Aged Brie", 10, 0),
                 new Item("Vest of Hermes", 5, 7),
                 new Item("Backstage passes to a TAFKAL80ETC concert", 10, 24),
-                new Item("Sulfuras, Hand of Ragnaros", 0, 80)
+                new Item("Sulfuras, Hand of Ragnaros", 0, 80),
+                new Item("Sulfuras, Hand of Ragnaros", -1, 80)
         };
 
         this.gildedRose = new GildedRose( this.items );
@@ -48,7 +49,8 @@ public class GildedRoseTest {
             "Aged Brie, 9, 1\n" +
             "Vest of Hermes, 4, 6\n" +
             "Backstage passes to a TAFKAL80ETC concert, 9, 26\n" +
-            "Sulfuras, Hand of Ragnaros, 0, 80\n",
+            "Sulfuras, Hand of Ragnaros, 0, 80\n" +
+            "Sulfuras, Hand of Ragnaros, -1, 80\n",
             this.gildedRose.toString()
         );
     }
@@ -64,7 +66,8 @@ public class GildedRoseTest {
                 "Aged Brie, -1, 12\n" +
                 "Vest of Hermes, -6, 0\n" +
                 "Backstage passes to a TAFKAL80ETC concert, -1, 0\n" +
-                "Sulfuras, Hand of Ragnaros, 0, 80\n",
+                "Sulfuras, Hand of Ragnaros, 0, 80\n" +
+                "Sulfuras, Hand of Ragnaros, -1, 80\n",
                 this.gildedRose.toString()
         );
     }


### PR DESCRIPTION
### Explicacion general
- Ahora que tenemos nuestro `ItemCategory` empezamos a crear nuevas categorias para los items que tienen comportamientos particulares.
- Empezamos creando una categoria para el item legendario `Sulfuras`.

- Todos los tests siguen pasando.

### Paso a paso del refactor
1. Creo la clase `SulfurasCategory` cuyo comportamiento es no hacer nada cuando se llama a los metodos `updateQuality`, `updateSellIn` y `updatedExpired` ya que es un item legendario.
2. Borro los `if (item.name.equals("Sulfuras, Hand of Ragnaros"))` del `RegularItemCategory` ya que existe una clase propia para aplicar este comportamiento.
3. En el metodo `categorize` de `GildedRose` agrego que si el nombre del item es Sulfuras devuelve una instancia de `SulfurasCategory` en lugar de `RegularItemCategory`.
4. Dado que el metodo `updateSellIn` solo tiene un comportamiento distinto para el caso de Sulfuras lo envio a la interface `ItemCategory` como metodo `default` y borro su sobreescritura en `RegularItemCategory`.
5. Con este refactor se hace visible que no estabamos testeando el metodo `updateExpired` para el caso de sulfuras, por lo que agrego un nuevo item con `sellIn = -1` para poder subir la cobertura de nuevo a 100%.